### PR TITLE
Update bouncycastle libs from 1.77 to 1.80

### DIFF
--- a/db-client-java/build.gradle
+++ b/db-client-java/build.gradle
@@ -47,8 +47,8 @@ dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"
     implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
     implementation 'org.slf4j:slf4j-api:2.0.9'
-    implementation "org.bouncycastle:bcprov-jdk18on:1.77"
-    implementation "org.bouncycastle:bcpkix-jdk18on:1.77"
+    implementation "org.bouncycastle:bcprov-jdk18on:1.80"
+    implementation "org.bouncycastle:bcpkix-jdk18on:1.80"
 
     implementation platform("io.opentelemetry:opentelemetry-bom:${openTelemetryVersion}")
     implementation "io.opentelemetry:opentelemetry-api"


### PR DESCRIPTION
Update bouncycastle libs to 1.80
### Motivation
Version below 1.78 contains vulnerabilities reported.

